### PR TITLE
fix for interspersed null characters on read with non-default charset

### DIFF
--- a/src/main/java/com/healthmarketscience/jackcess/impl/ColumnImpl.java
+++ b/src/main/java/com/healthmarketscience/jackcess/impl/ColumnImpl.java
@@ -1205,11 +1205,15 @@ public class ColumnImpl implements Column, Comparable<ColumnImpl> {
     int dataLength = dataEnd - dataStart;
 
     if(inCompressedMode) {
-      byte[] tmpData = new byte[dataLength * 2];
+      int bytesPerCharacter = 2;  // default
+      if (!getCharset().name().equals("UTF-16LE")) {
+        bytesPerCharacter = 1;
+      }
+      byte[] tmpData = new byte[dataLength * bytesPerCharacter];
       int tmpIdx = 0;
       for(int i = dataStart; i < dataEnd; ++i) {
         tmpData[tmpIdx] = data[i];
-        tmpIdx += 2;
+        tmpIdx += bytesPerCharacter;
       } 
       data = tmpData;
       dataStart = 0;


### PR DESCRIPTION
Fix for

```none
L a t i n   C a p i t a l   L e t t e r
```

issue mentioned in

https://sourceforge.net/p/jackcess/bugs/139/#2a5e

I'm happy to try and write a test case too, but not sure how to approach it as it involves non-standard data in the table. If you have any suggestions, please let me know.