### PR TITLE
Allow negative autonumber insert

### DIFF
--- a/src/main/java/com/healthmarketscience/jackcess/impl/ColumnImpl.java
+++ b/src/main/java/com/healthmarketscience/jackcess/impl/ColumnImpl.java
@@ -1939,7 +1939,7 @@ public class ColumnImpl implements Column, Comparable<ColumnImpl> {
       throws IOException
     {
       int inAutoNum = toNumber(inRowValue).intValue();
-      if(inAutoNum <= INVALID_AUTO_NUMBER) {
+      if(inAutoNum <= INVALID_AUTO_NUMBER && !getTable().isAllowAutoNumberInsert()) {
         throw new IOException(withErrorContext(
                 "Invalid auto number value " + inAutoNum));
       }

--- a/src/test/java/com/healthmarketscience/jackcess/impl/AutoNumberTest.java
+++ b/src/test/java/com/healthmarketscience/jackcess/impl/AutoNumberTest.java
@@ -242,12 +242,7 @@ public class AutoNumberTest extends TestCase
 
     assertEquals(13, ((TableImpl)table).getLastLongAutoNumber());
 
-    try {
-      table.addRow(-10, "uh-uh");
-      fail("IOException should have been thrown");
-    } catch(IOException e) {
-      // success
-    }
+    table.addRow(-10, "non-positives are now allowed");
 
     row = table.addRow(Column.AUTO_NUMBER, "row14");
     assertEquals(14, ((Integer)row[0]).intValue());
@@ -262,23 +257,18 @@ public class AutoNumberTest extends TestCase
 
     assertEquals(45, ((TableImpl)table).getLastLongAutoNumber());
 
-    row13.put("a", -1);
-
-    try {
-      table.updateRow(row13);
-      fail("IOException should have been thrown");
-    } catch(IOException e) {
-      // success
-    }
+    row13.put("a", -1);  // non-positives are now allowed
+    table.updateRow(row13);
 
     assertEquals(45, ((TableImpl)table).getLastLongAutoNumber());
 
     row13.put("a", 55);
 
-    table.setAllowAutoNumberInsert(null);
+    // reset to db-level policy (which in this case is "false")
+    table.setAllowAutoNumberInsert(null);  
 
-    row13 = table.updateRow(row13);
-    assertEquals(45, row13.get("a"));
+    row13 = table.updateRow(row13);  // no change, as confirmed by...
+    assertEquals(-1, row13.get("a"));
 
     assertEquals(45, ((TableImpl)table).getLastLongAutoNumber());
     


### PR DESCRIPTION
The Access Database Engine allows us to insert arbitrary non-positive values into an AutoNumber(Long_Integer) field. It would be nice if Jackcess allowed it, too.