### PR TITLE
Create a Relationship with a specific name

### DIFF
--- a/src/main/java/com/healthmarketscience/jackcess/RelationshipBuilder.java
+++ b/src/main/java/com/healthmarketscience/jackcess/RelationshipBuilder.java
@@ -57,7 +57,8 @@ public class RelationshipBuilder
   private String _fromTable;
   private String _toTable;
   private List<String> _fromCols = new ArrayList<String>();
-  private List<String> _toCols = new ArrayList<String>(); 
+  private List<String> _toCols = new ArrayList<String>();
+  private String _name = null;
 
   public RelationshipBuilder(Table fromTable, Table toTable) {
     this(fromTable.getName(), toTable.getName());
@@ -142,6 +143,16 @@ public class RelationshipBuilder
     }
     return this;
   }
+  
+  /**
+   * Sets a specific name for this relationship.
+   * 
+   * Default = null, meaning that the standard Access naming convention will be used. 
+   */
+  public RelationshipBuilder setName(String relationshipName) {
+    _name = relationshipName;
+    return this;
+  }
 
   public boolean hasReferentialIntegrity() {
     return !hasFlag(RelationshipImpl.NO_REFERENTIAL_INTEGRITY_FLAG);
@@ -165,6 +176,10 @@ public class RelationshipBuilder
 
   public List<String> getToColumns() {
     return _toCols;
+  }
+  
+  public String getName() {
+    return _name;
   }
   
   /**

--- a/src/main/java/com/healthmarketscience/jackcess/impl/DatabaseImpl.java
+++ b/src/main/java/com/healthmarketscience/jackcess/impl/DatabaseImpl.java
@@ -1237,12 +1237,18 @@ public class DatabaseImpl implements Database
     // - the total name is limited to (max - 3)
     int maxIdLen = getFormat().MAX_INDEX_NAME_LENGTH;
     int limit = (maxIdLen / 2) - 3;
-    String origName = creator.getPrimaryTable().getName();
-    if(origName.length() > limit) {
-      origName = origName.substring(0, limit);
+    String specifiedName = creator.getName();
+    String origName = null;
+    if (specifiedName != null) {
+      origName = specifiedName;
+    } else {
+      origName = creator.getPrimaryTable().getName();
+      if(origName.length() > limit) {
+        origName = origName.substring(0, limit);
+      }
+      origName += creator.getSecondaryTable().getName();
     }
     limit = maxIdLen - 3;
-    origName += creator.getSecondaryTable().getName();
     if(origName.length() > limit) {
       origName = origName.substring(0, limit);
     }

--- a/src/main/java/com/healthmarketscience/jackcess/impl/RelationshipCreator.java
+++ b/src/main/java/com/healthmarketscience/jackcess/impl/RelationshipCreator.java
@@ -60,6 +60,10 @@ public class RelationshipCreator extends DBMutator
   {
     super(database);
   }
+  
+  public String getName() {
+    return _name;
+  }
 
   public TableImpl getPrimaryTable() {
     return _primaryTable;
@@ -89,6 +93,7 @@ public class RelationshipCreator extends DBMutator
     throws IOException 
   {
     _relationship = relationship;
+    _name = relationship.getName();
     
     validate();
 

--- a/src/test/java/com/healthmarketscience/jackcess/TableUpdaterTest.java
+++ b/src/test/java/com/healthmarketscience/jackcess/TableUpdaterTest.java
@@ -44,7 +44,7 @@ public class TableUpdaterTest extends TestCase
     for (final FileFormat fileFormat : SUPPORTED_FILEFORMATS) {
       Database db = create(fileFormat);
 
-      doTestUpdating(db, false, true);
+      doTestUpdating(db, false, true, null);
  
       db.close();
     }    
@@ -54,7 +54,7 @@ public class TableUpdaterTest extends TestCase
     for (final FileFormat fileFormat : SUPPORTED_FILEFORMATS) {
       Database db = create(fileFormat);
 
-      doTestUpdating(db, true, true);
+      doTestUpdating(db, true, true, null);
  
       db.close();
     }    
@@ -64,13 +64,23 @@ public class TableUpdaterTest extends TestCase
     for (final FileFormat fileFormat : SUPPORTED_FILEFORMATS) {
       Database db = create(fileFormat);
 
-      doTestUpdating(db, false, false);
+      doTestUpdating(db, false, false, null);
  
       db.close();
     }    
   }
 
-  private void doTestUpdating(Database db, boolean oneToOne, boolean enforce) 
+  public void testTableUpdatingNamedRelationship() throws Exception {
+    for (final FileFormat fileFormat : SUPPORTED_FILEFORMATS) {
+      Database db = create(fileFormat);
+
+      doTestUpdating(db, false, true, "FKnun3jvv47l9kyl74h85y8a0if");
+ 
+      db.close();
+    }    
+  }
+
+  private void doTestUpdating(Database db, boolean oneToOne, boolean enforce, String relationshipName) 
     throws Exception
   {
     Table t1 = new TableBuilder("TestTable")
@@ -111,10 +121,18 @@ public class TableUpdaterTest extends TestCase
       rb.setReferentialIntegrity()
         .setCascadeDeletes();
     }
+    
+    if (relationshipName != null) {
+      rb.setName(relationshipName);
+    }
 
     Relationship rel = rb.toRelationship(db);
 
-    assertEquals("TestTableTestTable2", rel.getName());
+    if (relationshipName == null) {
+      assertEquals("TestTableTestTable2", rel.getName());
+    } else {
+      assertEquals(relationshipName, rel.getName());
+    }
     assertSame(t1, rel.getFromTable());
     assertEquals(Arrays.asList(t1.getColumn("id")), rel.getFromColumns());
     assertSame(t2, rel.getToTable());


### PR DESCRIPTION
Some applications (e.g., Hibernate) prefer to use their own names for FK constraints.